### PR TITLE
Adjust for new Hetzner Cloud API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 hetzner-dyndns-docker
 =====================
 
-⚠️ **This code does use the old [DNS API](https://dns.hetzner.com/api-docs) and does not work if you migrate your DNS entries to Hetzner Console**  ⚠️
-
 Dockerfile and Ansible playbooks to update DNS entry on Hetzner grapped from Fritzbox.
 
 The docker container executes the playbook every 5 minutes.
+
+⚠️ **This code does use the new Hetzner Cloud API** ⚠️
+
+It does not work anymore if you have not migrate your DNS entries to Hetzner Console. Keep in mind that
+you have to generate a new API token in Hetzner Console after migrating the DNS entries.
 
 Build
 -----

--- a/dyndns.yml
+++ b/dyndns.yml
@@ -25,18 +25,18 @@
 
     - name: Get Zone ID for {{ dns_zone }}
       ansible.builtin.uri:
-        url: "https://dns.hetzner.com/api/v1/zones?name={{ dns_zone }}"
+        url: "https://api.hetzner.cloud/v1/zones?name={{ dns_zone }}"
         method: GET
         headers:
-          Auth-API-Token: "{{ api_key }}"
+          Authorization: "Bearer {{ api_key }}"
       register: zone_id
 
     - name: Get all DNS Records for Zone {{ dns_zone }}
       ansible.builtin.uri:
-        url: "https://dns.hetzner.com/api/v1/records?zone_id={{ zone_id.json.zones[0].id }}"
+        url: "https://api.hetzner.cloud/v1/zones/{{ zone_id.json.zones[0].id }}/rrsets"
         method: GET
         headers:
-          Auth-API-Token: "{{ api_key }}"
+          Authorization: "Bearer {{ api_key }}"
       register: dns_records
 
 #    - debug:

--- a/manage_record.yml
+++ b/manage_record.yml
@@ -12,9 +12,9 @@
       set_fact:
         dns_record_id: "{{ item.id }}"
         dns_record_type: "{{ item.type }}"
-        dns_record_value: "{{ item.value }}"
+        dns_record_value: "{{ item.records[0].value }}"
       when: item.name == dyndns_name
-      loop: "{{ dns_records.json.records }}"
+      loop: "{{ dns_records.json.rrsets }}"
 
     - name: Assert that the Record is from Type A
       ansible.builtin.assert:
@@ -26,35 +26,30 @@
 #    - debug:
 #        var: dns_record_id
 
+    - name: DYNDNS Record exist, will delete old entry
+      ansible.builtin.uri:
+        url: "https://api.hetzner.cloud/v1/zones/{{ zone_id.json.zones[0].id }}/rrsets/{{ dyndns_name }}/A"
+        method: DELETE
+        headers:
+          Authorization: "Bearer {{ api_key }}"
+        status_code: 201
+      when: (dns_record_id | length > 0 and dns_record_value != external_ip_address and external_ip_address | length > 0)
+
     - name: DYNDNS Record {{ dyndns_name }} does NOT exist, will create it with external IP as {{ external_ip_address }}
       ansible.builtin.uri:
-        url: "https://dns.hetzner.com/api/v1/records"
+        url: "https://api.hetzner.cloud/v1/zones/{{ zone_id.json.zones[0].id }}/rrsets"
         method: POST
         headers:
-          Auth-API-Token: "{{ api_key }}"
+          Authorization: "Bearer {{ api_key }}"
         body_format: json
         body:
           name: "{{ dyndns_name }}"
           type: "A"
-          value: "{{ external_ip_address }}"
-          zone_id: "{{ zone_id.json.zones[0].id }}"
+          records:
+            - value: "{{ external_ip_address }}"
           ttl: 60
+        status_code: 201
       when: (dns_record_id | length == 0 and external_ip_address | length > 0)
-
-    - name: DYNDNS Record does exist, will update it with external IP as {{ external_ip_address }} if it had changed
-      ansible.builtin.uri:
-        url: "https://dns.hetzner.com/api/v1/records/{{ dns_record_id }}"
-        method: PUT
-        headers:
-          Auth-API-Token: "{{ api_key }}"
-        body_format: json
-        body:
-          name: "{{ dyndns_name }}"
-          type: "A"
-          value: "{{ external_ip_address }}"
-          zone_id: "{{ zone_id.json.zones[0].id }}"
-          ttl: 60
-      when: (dns_record_id | length > 0 and dns_record_value != external_ip_address and external_ip_address | length > 0)
 
   rescue:
     - name: There was an error


### PR DESCRIPTION
Hetzner recently integrated the DNS API into the Cloud API as described [here](https://docs.hetzner.com/networking/dns/migration-to-hetzner-console/process). This PR uses the new API.